### PR TITLE
Update imports to ESM and update dependencies

### DIFF
--- a/build.js
+++ b/build.js
@@ -6,10 +6,10 @@ import fs from 'fs';
 import path from 'path';
 import plantuml from 'node-plantuml';
 import fsextra from 'fs-extra';
-import docsifyTemplate from './docsify.template.js';
 import mdpdf from 'md-to-pdf';
 import https from 'https';
 import http from 'http';
+import docsifyTemplate from './docsify.template.js';
 let markdownpdf = mdpdf.mdToPdf;
 
 const DIST_BACKUP_FOLDER_SUFFIX = '_bk';
@@ -714,7 +714,7 @@ const generateWebMD = async (tree, options) => {
     }
 
     if (options.DOCSIFY_TEMPLATE && options.DOCSIFY_TEMPLATE !== '') {
-        docsifyTemplate = require(path.join(process.cwd(), options.DOCSIFY_TEMPLATE));
+        docsifyTemplate = import(path.join(process.cwd(), options.DOCSIFY_TEMPLATE));
     }
 
     //docsify homepage
@@ -746,7 +746,7 @@ const generateWebMD = async (tree, options) => {
     return Promise.all(filePromises);
 };
 
-const build = async (options, conf) => {
+export const build = async (options, conf) => {
     let start_date = new Date();
     const bkFolderName = options.DIST_FOLDER + DIST_BACKUP_FOLDER_SUFFIX;
 
@@ -810,4 +810,3 @@ const build = async (options, conf) => {
 
     console.log(chalk.green(`built in ${(new Date() - start_date) / 1000} seconds`));
 };
-exports.build = build;

--- a/build.js
+++ b/build.js
@@ -1,24 +1,27 @@
 #!/usr/bin/env node
 
-const chalk = require('chalk');
-const fs = require('fs');
-const path = require('path');
-const fsextra = require('fs-extra');
-let docsifyTemplate = require('./docsify.template.js');
-const markdownpdf = require('md-to-pdf').mdToPdf;
-const http = require('http');
+import chalk from 'chalk';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import plantuml from 'node-plantuml';
+import fsextra from 'fs-extra';
+import docsifyTemplate from './docsify.template.js';
+import mdpdf from 'md-to-pdf';
+import https from 'https';
+import http from 'http';
+let markdownpdf = mdpdf.mdToPdf;
 
 const DIST_BACKUP_FOLDER_SUFFIX = '_bk';
 
-const {
+import {
     encodeURIPath,
     makeDirectory,
     readFile,
     writeFile,
     plantUmlServerUrl,
     plantumlVersions
-} = require('./utils.js');
-const { date } = require('joi');
+} from './utils.js';
 
 const getMime = (format) => {
     if (format == 'svg') return `image/svg+xml`;
@@ -29,7 +32,7 @@ const httpGet = async (url) => {
     // return new pending promise
     return new Promise((resolve, reject) => {
         // select http or https module, depending on reqested url
-        const lib = url.startsWith('https') ? require('https') : require('http');
+        const lib = url.startsWith('https') ? https : http;
         const request = lib.get(url, (response) => {
             // handle http errors
             if (response.statusCode < 200 || response.statusCode > 299) {
@@ -143,8 +146,6 @@ const generateImages = async (tree, options, onImageGenerated, conf) => {
     if (options.PLANTUML_VERSION === 'latest') ver = plantumlVersions.find((v) => v.isLatest);
     if (!ver) throw new Error(`PlantUML version ${options.PLANTUML_VERSION} not supported`);
 
-    const crypto = require('crypto');
-
     for (const item of tree) {
         totalImages += item.pumlFiles.length;
     }
@@ -153,7 +154,7 @@ const generateImages = async (tree, options, onImageGenerated, conf) => {
         for (const pumlFile of item.pumlFiles) {
             //There was a bug with this, that's why I require it inside the loop
             process.env.PLANTUML_HOME = path.join(__dirname, 'vendor', ver.jar);
-            const plantuml = require('node-plantuml');
+
 
             // Calculate hash of current puml content
             let cksum = crypto

--- a/cli.collect.js
+++ b/cli.collect.js
@@ -3,7 +3,7 @@ import joi from 'joi';
 import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
-import { plantumlVersions } from './utils';
+import { plantumlVersions } from './utils.js';
 
 const validate = (schema) => (answers) => {
     //just in case
@@ -14,7 +14,7 @@ const validate = (schema) => (answers) => {
     }
 };
 
-module.exports = async (currentConfiguration, conf, program) => {
+export const cmdCollect = async (currentConfiguration, conf, program) => {
     if (!currentConfiguration.PROJECT_NAME || program.config) {
         responses = await inquirer.prompt({
             type: 'input',

--- a/cli.collect.js
+++ b/cli.collect.js
@@ -1,9 +1,9 @@
-const inquirer = require('inquirer');
-const joi = require('joi');
-const fs = require('fs');
-const path = require('path');
-const chalk = require('chalk');
-const { plantumlVersions } = require('./utils');
+import inquirer from 'inquirer';
+import joi from 'joi';
+import fs from 'fs';
+import path from 'path';
+import chalk from 'chalk';
+import { plantumlVersions } from './utils';
 
 const validate = (schema) => (answers) => {
     //just in case

--- a/cli.help.js
+++ b/cli.help.js
@@ -1,7 +1,7 @@
 import figlet from 'figlet';
 import chalk from 'chalk';
 
-module.exports = () => {
+export default () => {
     console.log(chalk.blue(figlet.textSync('c4builder')));
     console.log(`
 Full documentation

--- a/cli.help.js
+++ b/cli.help.js
@@ -1,5 +1,5 @@
-const figlet = require('figlet');
-const chalk = require('chalk');
+import figlet from 'figlet';
+import chalk from 'chalk';
 
 module.exports = () => {
     console.log(chalk.blue(figlet.textSync('c4builder')));
@@ -7,7 +7,7 @@ module.exports = () => {
 Full documentation
 ${chalk.blue('https://adrianvlupu.github.io/C4-Builder/')}
 
-CONFIGURATION OPTIONS 
+CONFIGURATION OPTIONS
 ${chalk.cyan('Project Name')}
 Will be used as the #header of the resulting documentation.
 ${chalk.cyan('HomePage Name')}

--- a/cli.js
+++ b/cli.js
@@ -1,20 +1,20 @@
-const figlet = require('figlet');
-const program = require('commander');
-const package = require('./package.json');
-const chalk = require('chalk');
-const path = require('path');
+import figlet from 'figlet';
+import program from 'commander';
+import _package from './package.json';
+import chalk from 'chalk';
+import path from 'path';
 
-const Configstore = require('configstore');
+import Configstore from 'configstore';
 
-const cmdHelp = require('./cli.help');
-const cmdNewProject = require('./cli.new');
-const cmdList = require('./cli.list');
-const cmdSite = require('./cli.site');
-const cmdCollect = require('./cli.collect');
-const { build } = require('./build');
-const watch = require('node-watch');
+import cmdHelp from './cli.help';
+import cmdNewProject from './cli.new');
+import cmdList from './cli.list';
+import cmdSite from './cli.site';
+import cmdCollect from './cli.collect';
+import { build } from './build';
+import watch from 'node-watch';
 
-const { clearConsole } = require('./utils.js');
+import { clearConsole } from './utils.js';
 
 const intro = () => {
     console.log(chalk.blue(figlet.textSync('c4builder')));
@@ -58,7 +58,7 @@ const getOptions = (conf) => {
 
 module.exports = async () => {
     program
-        .version(package.version)
+        .version(_package.version)
         .option('new', 'create a new project from template')
         .option('config', 'change configuration for the current directory')
         .option('list', 'display the current configuration')

--- a/cli.js
+++ b/cli.js
@@ -1,19 +1,17 @@
 import figlet from 'figlet';
 import program from 'commander';
-import _package from './package.json';
 import chalk from 'chalk';
 import path from 'path';
-
 import Configstore from 'configstore';
-
-import cmdHelp from './cli.help';
-import cmdNewProject from './cli.new';
-import cmdList from './cli.list';
-import cmdSite from './cli.site';
-import cmdCollect from './cli.collect';
-import { build } from './build';
 import watch from 'node-watch';
 
+import _package from './package.json' with { type: "json" };
+import cmdHelp from './cli.help.js';
+import cmdNewProject from './cli.new.js';
+import cmdList from './cli.list.js';
+import cmdSite from './cli.site.js';
+import { cmdCollect } from './cli.collect.js';
+import { build } from './build.js';
 import { clearConsole } from './utils.js';
 
 const intro = () => {
@@ -56,7 +54,7 @@ const getOptions = (conf) => {
     };
 };
 
-module.exports = async () => {
+export default async () => {
     program
         .version(_package.version)
         .option('new', 'create a new project from template')

--- a/cli.js
+++ b/cli.js
@@ -7,7 +7,7 @@ import path from 'path';
 import Configstore from 'configstore';
 
 import cmdHelp from './cli.help';
-import cmdNewProject from './cli.new');
+import cmdNewProject from './cli.new';
 import cmdList from './cli.list';
 import cmdSite from './cli.site';
 import cmdCollect from './cli.collect';

--- a/cli.list.js
+++ b/cli.list.js
@@ -1,4 +1,4 @@
-const chalk = require('chalk');
+import chalk from 'chalk';
 
 module.exports = (currentConfiguration) => {
     console.log(`
@@ -28,7 +28,7 @@ Generate multiple markdown files: ${
         currentConfiguration.GENERATE_MD !== undefined
             ? chalk.green(currentConfiguration.GENERATE_MD)
             : chalk.red('not set')
-    }    
+    }
     ${
         currentConfiguration.generateMD
             ? `include basic navigation: ${chalk.green(currentConfiguration.INCLUDE_NAVIGATION || false)}

--- a/cli.list.js
+++ b/cli.list.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 
-module.exports = (currentConfiguration) => {
+export default (currentConfiguration) => {
     console.log(`
 CURRENT CONFIGURATION
 

--- a/cli.new.js
+++ b/cli.new.js
@@ -4,10 +4,14 @@ import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
 import fsextra from 'fs-extra';
-import { plantumlVersions } from './utils';
 import Configstore from 'configstore';
 
-import { readFile, writeFile, makeDirectory } from './utils.js';
+import {
+    makeDirectory,
+    readFile,
+    writeFile,
+    plantumlVersions
+} from './utils.js';
 
 const validate = (schema) => (answers) => {
     //just in case
@@ -82,7 +86,7 @@ const generateTemplate = async (dir, projectName, plantumlVersion) => {
     await build(dir);
 };
 
-module.exports = async () => {
+export default async () => {
     console.log('\nThis will create a new folder with the name of the project');
 
     let responses;

--- a/cli.new.js
+++ b/cli.new.js
@@ -1,14 +1,13 @@
-const figlet = require('figlet');
-const inquirer = require('inquirer');
-const joi = require('joi');
-const chalk = require('chalk');
-const fs = require('fs');
-const path = require('path');
-const fsextra = require('fs-extra');
-const { plantumlVersions } = require('./utils');
-const Configstore = require('configstore');
+import inquirer from 'inquirer';
+import joi from 'joi';
+import chalk from 'chalk';
+import fs from 'fs';
+import path from 'path';
+import fsextra from 'fs-extra';
+import { plantumlVersions } from './utils';
+import Configstore from 'configstore';
 
-const { readFile, writeFile, makeDirectory } = require('./utils.js');
+import { readFile, writeFile, makeDirectory } from './utils.js';
 
 const validate = (schema) => (answers) => {
     //just in case

--- a/cli.site.js
+++ b/cli.site.js
@@ -1,6 +1,6 @@
-const chalk = require('chalk');
-const path = require('path');
-const express = require('express');
+import chalk from 'chalk';
+import path from 'path';
+import express from 'express';
 const app = express();
 
 module.exports = (currentConfiguration, program) => {

--- a/cli.site.js
+++ b/cli.site.js
@@ -3,7 +3,7 @@ import path from 'path';
 import express from 'express';
 const app = express();
 
-module.exports = (currentConfiguration, program) => {
+export default (currentConfiguration, program) => {
     if (!currentConfiguration.DIST_FOLDER) return console.log(chalk.red('No destination folder configured'));
 
     const port = program.port || currentConfiguration.WEB_PORT;

--- a/docsify.template.js
+++ b/docsify.template.js
@@ -9,10 +9,10 @@
 //     },
 //     stylesheet: ''
 //   }
-module.exports = (options) => {
+export default (options) => {
     return `<!DOCTYPE html>
     <html lang="en">
-    
+
     <head>
         <meta charset="UTF-8">
         <title>${options.name}</title>
@@ -22,7 +22,7 @@ module.exports = (options) => {
         content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
         <link rel="stylesheet" href="${options.stylesheet}">
     </head>
-    
+
     <body>
         <div id="app"></div>
         <script>
@@ -36,6 +36,6 @@ module.exports = (options) => {
             `<script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>`
         }
     </body>
-    
+
     </html>`;
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
 //entry point
-import cli from 'cli';
+import cli from './cli';
 cli();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
 //entry point
-import cli from './cli';
+import cli from './cli.js';
 cli();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
 //entry point
-let cli = require('./cli');
+import cli from 'cli';
 cli();

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.18",
   "description": "A CLI tool designed to compile a folder structure of markdowns and plant uml files into a site, pdf, single file markdown or a collection of markdowns with links",
   "main": "index.js",
+  "type": "module",
   "bin": {
     "c4builder": "./index.js"
   },

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const zlib = require('node:zlib');
+import fs from 'fs';
+import zlib from 'node:zlib';
 
 const makeDirectory = (path) =>
     new Promise((resolve) => {

--- a/utils.js
+++ b/utils.js
@@ -1,14 +1,14 @@
 import fs from 'fs';
 import zlib from 'node:zlib';
 
-const makeDirectory = (path) =>
+export const makeDirectory = (path) =>
     new Promise((resolve) => {
         fs.mkdir(path, () => {
             return resolve();
         });
     });
 
-const readFile = (path, type) =>
+export const readFile = (path, type) =>
     new Promise((resolve, reject) => {
         fs.readFile(path, type, (err, data) => {
             if (err) return reject(err);
@@ -17,7 +17,7 @@ const readFile = (path, type) =>
         });
     });
 
-const writeFile = (path, data) =>
+export const writeFile = (path, data) =>
     new Promise((resolve, reject) => {
         fs.writeFile(path, data, (err, res) => {
             if (err) return reject(err);
@@ -26,11 +26,11 @@ const writeFile = (path, data) =>
         });
     });
 
-const writeOnSameLine = async (message, fn) => {
+export const writeOnSameLine = async (message, fn) => {
     process.stdout.write(`${message}\r`);
 };
 
-const encodeURIPath = (path) => {
+export const encodeURIPath = (path) => {
     path = path.split('\\').join('/');
     return encodeURI(path);
 };
@@ -58,7 +58,7 @@ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABI
 CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
  */
-const urlTextFrom = (s) => {
+export const urlTextFrom = (s) => {
     let opt = { level: 9 };
     let d = zlib.deflateRawSync(new Buffer.from(s), opt);
     let b = encode64(String.fromCharCode(...d.subarray(0)));
@@ -117,15 +117,15 @@ const urlTextFrom = (s) => {
     }
 };
 
-const plantUmlServerUrl = (baseURL, imageFormat, content) =>
+export const plantUmlServerUrl = (baseURL, imageFormat, content) =>
     `${baseURL}/${imageFormat}/0/${urlTextFrom(content)}`;
 
-const clearConsole = () => {
+export const clearConsole = () => {
     process.stdout.write('\x1b[2J');
     process.stdout.write('\x1b[0f');
 };
 
-const plantumlVersions = [
+export const plantumlVersions = [
     {
         version: '1.2020.07',
         jar: 'plantuml-1.2020.7.jar'
@@ -152,14 +152,3 @@ const plantumlVersions = [
         jar: 'plantuml-1.2023.10.jar'
     }
 ];
-
-module.exports = {
-    makeDirectory,
-    readFile,
-    writeFile,
-    encodeURIPath,
-    writeOnSameLine,
-    clearConsole,
-    plantUmlServerUrl,
-    plantumlVersions
-};


### PR DESCRIPTION
We were having problems building this library due to `node-waf` issues, so we decided to update various dependencies. After that, we started seeing issues relating to `require(...)` being deprecated and using ESM imports, so we reworked all the imports to be ESM style.

We haven't used all functionality modified here, but our own internal documentation builds with this branch, so we'll continue with this for now.

We do not intend to present this functionality to upstream.